### PR TITLE
[fix] RDFa person tags for mandateesByPerson on the government-body page

### DIFF
--- a/app/templates/view/government-body.hbs
+++ b/app/templates/view/government-body.hbs
@@ -99,15 +99,16 @@
     </p>
     <div class="au-o-grid">
       {{#each (sort-by "person.familyName" this.mandateesByPerson) as |person|}}
-        <div class="au-o-grid__item au-u-1-2" resource={{person.uri}} typeof={{person.rdfaBindings.class}}>
+        <div class="au-o-grid__item au-u-1-2" resource={{person.person.uri}}
+          typeof={{person.person.rdfaBindings.class}}>
           <AuCard as |c|>
             <c.header>
               <AuHeading @level="2" @skin="4">
                 <LinkTo @route="view.person" @query={{hash resource=person.person.uri}}>
-                  <span property={{person.rdfaBindings.firstName}}>
+                  <span property={{person.person.rdfaBindings.firstName}}>
                     {{person.person.firstName}}
                   </span>
-                  <span property={{person.rdfaBindings.firstName}}>
+                  <span property={{person.person.rdfaBindings.firstName}}>
                     {{person.person.familyName}}
                   </span>
                 </LinkTo>


### PR DESCRIPTION
The person variable of the object was not selected, resulting in `undefined` RDFa-bindings being referenced, hence they weren't appearing.
The name and family name now appear in the RDFa data of the page for each mandatee.
**Example**:
```
Statement Collection #5 |  
-- | --
Entity | http://themis.vlaanderen.be/id/persoon/5fed907ee6670526694a0718
Attributes |  
rdf:type | person:Person
https://data.vlaanderen.be/ns/persoon#gebruikteVoornaam | Wouter
foaf:familyName | Beke
```