### PR TITLE
Disable Plausible on fastboot rendered pages

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -4,11 +4,13 @@ import ENV from 'frontend-themis/config/environment';
 
 export default class ApplicationRoute extends Route {
   @service plausible;
+  @service fastboot;
 
   beforeModel() {
     const { domain, apiHost } = ENV.plausible;
 
     if (
+      !this.fastboot.isFastBoot &&
       domain !== '{{ANALYTICS_APP_DOMAIN}}' &&
       apiHost !== '{{ANALYTICS_API_HOST}}'
     ) {

--- a/config/fastboot.js
+++ b/config/fastboot.js
@@ -1,11 +1,15 @@
 module.exports = function (environment) {
   return {
     buildSandboxGlobals(defaultGlobals) {
-      return Object.assign({}, defaultGlobals, {
-        // Enable BACKEND_URL and set to http://host (or http://localhost) for local development.
-        // or https://themis-test.vlaanderen.be if you use the proxied version
-        BACKEND_URL: 'http://host/',
+      // Enable BACKEND_URL and set to http://host (or http://localhost) for local development.
+      // or https://themis-test.vlaanderen.be if you use the proxied version
+      const BACKEND_URL = 'https://themis.vlaanderen.be/';
 
+      console.log(
+        `Using ${BACKEND_URL} as BACKEND_URL. You can change this setting in ./config/fastboot.js`,
+      );
+      return Object.assign({}, defaultGlobals, {
+        BACKEND_URL,
         // Fastboot support for Ember Data >= 4.12
         AbortController,
         fetch: fetch,

--- a/config/fastboot.js
+++ b/config/fastboot.js
@@ -3,7 +3,7 @@ module.exports = function (environment) {
     buildSandboxGlobals(defaultGlobals) {
       // Enable BACKEND_URL and set to http://host (or http://localhost) for local development.
       // or https://themis-test.vlaanderen.be if you use the proxied version
-      const BACKEND_URL = 'https://themis.vlaanderen.be/';
+      const BACKEND_URL = 'http://host/';
 
       console.log(
         `Using ${BACKEND_URL} as BACKEND_URL. You can change this setting in ./config/fastboot.js`,


### PR DESCRIPTION
Plausible uses local storage which is not available on fastboot rendered paged. Therefore we enable Plausible on non-fastboot rendered pages.